### PR TITLE
Check delays now output station/route names

### DIFF
--- a/src/data_access/CheckDelaysDataAccessObject.java
+++ b/src/data_access/CheckDelaysDataAccessObject.java
@@ -108,7 +108,7 @@ public class CheckDelaysDataAccessObject implements CheckDelaysDataAccessInterfa
                     JSONArray allResultsArray = nameResponseBody.getJSONArray("results");
                     for (int i = 0; i < allResultsArray.length(); i++) {
                         JSONObject resultObject = allResultsArray.getJSONObject(i);
-                        if (resultObject.getString("global_stop_id").equals(id.substring(0, id.length() - 1)) || resultObject.getString("parent_station_global_stop_id").equals(id.substring(0, id.length() - 1))) {
+                        if (resultObject.getString("global_stop_id").equals(id) || resultObject.getString("parent_station_global_stop_id").equals(id)) {
                             stationName = resultObject.getString("stop_name");
                             break;
                         }

--- a/src/data_access/CheckDelaysDataAccessObject.java
+++ b/src/data_access/CheckDelaysDataAccessObject.java
@@ -15,13 +15,13 @@ import java.util.ArrayList;
 public class CheckDelaysDataAccessObject implements CheckDelaysDataAccessInterface {
     public static final String API_URL = "https://external.transitapp.com/v3/public/route_details";
     public static final String API_URL_BY_STATION = "https://external.transitapp.com/v3/public/stop_departures";
-    public static final String API_URL_STATION_NAME = "https://external.transitapp.com/v3/stops/search_stops";
+    public static final String API_URL_STATION_NAME = "https://external.transitapp.com/v3/public/search_stops";
     public String lat = "43.6619003";
     public String lon = "-79.3914503";
     public String searchQuery = "";
     public String API_KEY = "";
     public String routeName = "";
-    public String stationName = "";
+    public String stationName = "the Station";
 
     public String getApiKey() {
         return API_KEY;
@@ -108,8 +108,9 @@ public class CheckDelaysDataAccessObject implements CheckDelaysDataAccessInterfa
                     JSONArray allResultsArray = nameResponseBody.getJSONArray("results");
                     for (int i = 0; i < allResultsArray.length(); i++) {
                         JSONObject resultObject = allResultsArray.getJSONObject(i);
-                        if (resultObject.getString("global_stop_id").equals(id) || resultObject.getString("stop_id").equals(id)) {
+                        if (resultObject.getString("global_stop_id").equals(id.substring(0, id.length() - 1)) || resultObject.getString("parent_station_global_stop_id").equals(id.substring(0, id.length() - 1))) {
                             stationName = resultObject.getString("stop_name");
+                            break;
                         }
                     }
                 } catch (IOException | JSONException e) {

--- a/src/data_access/CheckDelaysDataAccessObject.java
+++ b/src/data_access/CheckDelaysDataAccessObject.java
@@ -15,7 +15,13 @@ import java.util.ArrayList;
 public class CheckDelaysDataAccessObject implements CheckDelaysDataAccessInterface {
     public static final String API_URL = "https://external.transitapp.com/v3/public/route_details";
     public static final String API_URL_BY_STATION = "https://external.transitapp.com/v3/public/stop_departures";
+    public static final String API_URL_STATION_NAME = "https://external.transitapp.com/v3/stops/search_stops";
+    public String lat = "43.6619003";
+    public String lon = "-79.3914503";
+    public String searchQuery = "";
     public String API_KEY = "";
+    public String routeName = "";
+    public String stationName = "";
 
     public String getApiKey() {
         return API_KEY;
@@ -23,6 +29,14 @@ public class CheckDelaysDataAccessObject implements CheckDelaysDataAccessInterfa
 
     public void setApiKey(String apiKey) {
         this.API_KEY = apiKey;
+    }
+
+    public String getRouteName() {
+        return routeName;
+    }
+
+    public String getStationName() {
+        return stationName;
     }
 
 
@@ -41,6 +55,9 @@ public class CheckDelaysDataAccessObject implements CheckDelaysDataAccessInterfa
             JSONObject responseBody = new JSONObject(response.body().string());
 
             if (response.code() == 200) {
+                String routeName = responseBody.getJSONObject("route").getString("route_long_name");
+                this.routeName = routeName;
+
                 JSONArray allStopsArray = responseBody.getJSONArray("itineraries").getJSONObject(0).getJSONArray("stops");
                 ArrayList<Delay> delays = new ArrayList<Delay>();
                 DelayFactory delayFactory = new CommonDelayFactory();
@@ -76,7 +93,30 @@ public class CheckDelaysDataAccessObject implements CheckDelaysDataAccessInterfa
             assert response.body() != null;
             JSONObject responseBody = new JSONObject(response.body().string());
 
+
             if (response.code() == 200) {
+                Request nameRequest = new Request.Builder()
+                        .url(String.format(API_URL_STATION_NAME + "?lat=%s&lon=%s&query=\"%s\"", lat, lon, searchQuery))
+                        .addHeader("apiKey", API_KEY)
+                        .build();
+                try{
+                    Response nameResponse = client.newCall(nameRequest).execute();
+                    System.out.println(nameResponse);
+                    assert nameResponse.body() != null;
+                    JSONObject nameResponseBody = new JSONObject(nameResponse.body().string());
+
+                    JSONArray allResultsArray = nameResponseBody.getJSONArray("results");
+                    for (int i = 0; i < allResultsArray.length(); i++) {
+                        JSONObject resultObject = allResultsArray.getJSONObject(i);
+                        if (resultObject.getString("global_stop_id").equals(id) || resultObject.getString("stop_id").equals(id)) {
+                            stationName = resultObject.getString("stop_name");
+                        }
+                    }
+                } catch (IOException | JSONException e) {
+                    stationName = "Station"; // fallback name in case of name not found
+                }
+
+
                 JSONArray allRoutesArray = responseBody.getJSONArray("route_departures");
                 ArrayList<Delay> delays = new ArrayList<Delay>();
 

--- a/src/interface_adapter/check_delays/CheckDelaysPresenter.java
+++ b/src/interface_adapter/check_delays/CheckDelaysPresenter.java
@@ -20,6 +20,7 @@ public class CheckDelaysPresenter implements CheckDelaysOutputBoundary {
         CheckDelaysState checkDelaysState = checkDelaysViewModel.getState();
         checkDelaysState.setStationID(checkDelaysState.getStationID());
         checkDelaysState.setQueryType(checkDelaysState.getType());
+        checkDelaysState.setName(response.getName());
         checkDelaysState.setDelayStatus(checkDelaysState.getDelayStatus());
         checkDelaysViewModel.firePropertyChanged();
     }

--- a/src/interface_adapter/check_delays/CheckDelaysState.java
+++ b/src/interface_adapter/check_delays/CheckDelaysState.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 public class CheckDelaysState {
     private String stationID = "";
     private String queryType = "";
+    private String name = "";
     private String stationIDError = "";
     private boolean delayed;
 
@@ -22,6 +23,9 @@ public class CheckDelaysState {
 
     public void setQueryType(String queryType) {
         this.queryType = queryType;
+    }
+    public void setName(String name) {
+        this.name = name;
     }
 
     public void setDelayStatus(boolean delayed) {
@@ -52,17 +56,17 @@ public class CheckDelaysState {
     public String toString(){
         if (delayed) {
             if (queryType.equals("route")) {
-                return "Line " + stationID.substring(0, stationID.length() - 1) + " is delayed.";
+                return name + " is delayed. (" + stationID.substring(0, stationID.length() - 1) + ")";
             }
             else { // queryType == "station"
-                return "Lines at " + stationID.substring(0, stationID.length() - 1) + " is delayed.";
+                return "There is a delay at " + name + ". (" + stationID.substring(0, stationID.length() - 1) + ")";
             }
         } else { // not delayed
             if (queryType.equals("route")) {
-                return "There is no delay with " + stationID.substring(0, stationID.length() - 1) + ".";
+                return name + " has no delays. (" + stationID.substring(0, stationID.length() - 1) + ")";
             }
             else { // queryType == "station"
-                return "There is no delay at " + stationID.substring(0, stationID.length() - 1) + ".";
+                return "There are no delays at " + name + ". (" + stationID.substring(0, stationID.length() - 1) + ")";
             }
         }
     }

--- a/src/interface_adapter/check_delays/CheckDelaysState.java
+++ b/src/interface_adapter/check_delays/CheckDelaysState.java
@@ -56,17 +56,17 @@ public class CheckDelaysState {
     public String toString(){
         if (delayed) {
             if (queryType.equals("route")) {
-                return name + " is delayed. (" + stationID.substring(0, stationID.length() - 1) + ")";
+                return name + " is delayed. (" + stationID + ")";
             }
             else { // queryType == "station"
-                return "There is a delay at " + name + ". (" + stationID.substring(0, stationID.length() - 1) + ")";
+                return "There is a delay at " + name + ". (" + stationID + ")";
             }
         } else { // not delayed
             if (queryType.equals("route")) {
-                return name + " has no delays. (" + stationID.substring(0, stationID.length() - 1) + ")";
+                return name + " has no delays. (" + stationID + ")";
             }
             else { // queryType == "station"
-                return "There are no delays at " + name + ". (" + stationID.substring(0, stationID.length() - 1) + ")";
+                return "There are no delays at " + name + ". (" + stationID + ")";
             }
         }
     }

--- a/src/use_case/check_delays/CheckDelaysDataAccessInterface.java
+++ b/src/use_case/check_delays/CheckDelaysDataAccessInterface.java
@@ -7,4 +7,8 @@ public interface CheckDelaysDataAccessInterface {
     boolean checkDelaysByRoute(String id);
 
     boolean checkDelaysByStation(String id);
+
+    String getRouteName();
+
+    String getStationName();
 }

--- a/src/use_case/check_delays/CheckDelaysInteractor.java
+++ b/src/use_case/check_delays/CheckDelaysInteractor.java
@@ -1,6 +1,8 @@
 package use_case.check_delays;
 
+import entity.CommonDelayFactory;
 import entity.Delay;
+import entity.DelayFactory;
 import entity.Route;
 import use_case.check_delays.*;
 
@@ -11,6 +13,7 @@ import java.util.List;
 public class CheckDelaysInteractor implements CheckDelaysInputBoundary {
     final CheckDelaysDataAccessInterface checkDelaysDataAccessObject;
     final CheckDelaysOutputBoundary checkDelaysPresenter;
+    final DelayFactory delayFactory = new CommonDelayFactory();
 
     public CheckDelaysInteractor(CheckDelaysDataAccessInterface checkDelaysDataAccessObject, CheckDelaysOutputBoundary checkDelaysPresenter) {
         this.checkDelaysDataAccessObject = checkDelaysDataAccessObject;
@@ -23,11 +26,13 @@ public class CheckDelaysInteractor implements CheckDelaysInputBoundary {
         try {
             if (checkDelaysInputData.getType() == "route") { // check by route
                 boolean delayStatus = checkDelaysDataAccessObject.checkDelaysByRoute(checkDelaysInputData.getId());
-                CheckDelaysOutputData checkDelaysOutputData = new CheckDelaysOutputData(delayStatus, true);
+                String routeName = checkDelaysDataAccessObject.getRouteName();
+                CheckDelaysOutputData checkDelaysOutputData = new CheckDelaysOutputData(delayStatus, routeName, true);
                 checkDelaysPresenter.prepareSuccessView(checkDelaysOutputData);
             } else { // check by station
                 boolean delayStatus = checkDelaysDataAccessObject.checkDelaysByStation(checkDelaysInputData.getId());
-                CheckDelaysOutputData checkDelaysOutputData = new CheckDelaysOutputData(delayStatus, false);
+                String stationName = checkDelaysDataAccessObject.getStationName();
+                CheckDelaysOutputData checkDelaysOutputData = new CheckDelaysOutputData(delayStatus, stationName, false);
                 checkDelaysPresenter.prepareSuccessView(checkDelaysOutputData);
             }
         } catch (Exception e) {

--- a/src/use_case/check_delays/CheckDelaysOutputData.java
+++ b/src/use_case/check_delays/CheckDelaysOutputData.java
@@ -5,14 +5,20 @@ import java.util.HashMap;
 
 public class CheckDelaysOutputData {
     private final boolean status;
+    private final String name;
     private boolean useCaseFailed;
 
-    public CheckDelaysOutputData(boolean status, boolean useCaseFailed) {
+    public CheckDelaysOutputData(boolean status, String name, boolean useCaseFailed) {
         this.status = status;
+        this.name = name;
         this.useCaseFailed = useCaseFailed;
     }
 
     public boolean getDelayStatus() {
         return status;
+    }
+
+    public String getName() {
+        return name;
     }
 }

--- a/test/use_case/CheckDelaysInteractorTest.java
+++ b/test/use_case/CheckDelaysInteractorTest.java
@@ -32,6 +32,16 @@ public class CheckDelaysInteractorTest {
                         throw new RuntimeException("Error: Invalid route ID");
                 }
             }
+
+            @Override
+            public String getRouteName() {
+                return "Test Route";
+            }
+
+            @Override
+            public String getStationName() {
+                return "Test Station";
+            }
         };
 
         CheckDelaysOutputBoundary checkDelaysPresenterDelayed = new CheckDelaysOutputBoundary() {


### PR DESCRIPTION
Updated CheckDelays use case to feature station and route names in output.

_Note: Sation names may be limited to around UofT as there is no intuitive API to convert station_id into station names_
Suggested test station ids: TTC1ON:1038, TTC1ON:1059 ...
Workaround: change lat and lon values on line 19 and 20 of DAO to somewhere close to the desired station.

**Important: Copy and pasting ids into query box will result in an extra blank/unknown character in the query, please enter by hand or modify after pasting**